### PR TITLE
Added CVA6 core and Yocto repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,5 @@ Repository | URL/Instructions | TRISTAN Working Items | Partners                
 cve2       | [cve2](https://github.com/openhwgroup/cve2) | 2.2.5, 2.2.8, 2.5.7 | NXP, Synthara, Politecnico di Torino | Design and Verification in progress | Solderpad |
 TimeWeaver | [absint.com/timeweaver](https://www.absint.com/timeweaver/) | WI4.1.5 | AbsInt | Waiting for WI4.1.3 / WI2.2.1 | proprietary |
 CompCert   | [github.com/AbsInt/CompCert](https://github.com/AbsInt/CompCert) | WI4.2.4 | AbsInt | Waiting for WI2.5.4 | dual licensed (see repository) |
-
+CVA6       | [cva6](https://github.com/openhwgroup/cva6) | WI2.4.1, WI2.4.2, WI2.4.3, WI2.4.5 | Thales, Sysgo, TU Darmstadt, Bosch  | Design and Verification in progress | Solderpad |
+Yocto for CVA6 | [meta-cva6-yocto](https://github.com/openhwgroup/meta-cva6-yocto) | WI4.3.3 | Thales | Initial release | MIT |


### PR DESCRIPTION
Add repos for the CVA6 core and the Yocto Linux image generator.
We could consider adding core-v-verif and cva-sdk.